### PR TITLE
Add Option to Append Headers to Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```
-Usage: db++ [-h|--help] [-w|--wordlist <wordlist_file>] [-r|--recursive] [-u|--username <username>] [-p|--password <password>] [-t|--request-templates <request_templates>] [-k|--ignore-ssl-errors] [-s|--ignored-status-codes <ignore_codes>] [-c|--ignored-content-lengths <ignore_content_lengths>] [-X|--request-method <request_method>] [-T|--thread-count <thread_count>] [-d|--data <request_data>] [-D|--content-type <content_type>] <base_url> 
+Usage: ./db++ [-h|--help] [-w|--wordlist <wordlist_file>] [-r|--recursive] [-u|--username <username>] [-p|--password <password>] [-t|--request-templates <request_templates>] [-k|--ignore-ssl-errors] [-s|--ignored-status-codes <ignore_codes>] [-c|--ignored-content-lengths <ignore_content_lengths>] [-X|--request-method <request_method>] [-T|--thread-count <thread_count>] [-d|--data <request_data>] [-D|--content-type <content_type>] [-H|--headers <headers>] <base_url> 
 
     -h|--help                                              
                                                            Print this help message and exit                         
@@ -33,6 +33,8 @@ Usage: db++ [-h|--help] [-w|--wordlist <wordlist_file>] [-r|--recursive] [-u|--u
                                                            Body of the post request. Changes request_method to POST 
     -D|--content-type <content_type>                       
                                                            HTTP content type of the <request_data>. Default: x-www-form-urlencoded
+    -H|--headers <headers>                                 
+                                                           Headers to add to request. Default <none>                
      <base_url>                                            
                                                            URL to the server to attempt to query
 ```

--- a/models/header.h
+++ b/models/header.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+struct Header
+{
+    std::string name;
+    std::string value;
+};

--- a/parameters/arguments.cpp
+++ b/parameters/arguments.cpp
@@ -31,6 +31,11 @@ std::ostream& operator<<(std::ostream& out, const Arguments& args)
     for (auto& request_template : args.request_templates)
         out << '"' << request_template << "\" ";
     out << '\n';
+
+    out << "headers: ";
+    for (auto& header : args.headers)
+        out << "'" << header.name << "' = '" << header.value << "'" << '\n';
+    out << '\n';
     return out;
 }
 
@@ -122,6 +127,13 @@ ap::ArgumentParser<Arguments> createArgumentParser()
             "x-www-form-urlencoded"s,
             { "-D"s, "--content-type"s },
             "HTTP content type of the <request_data>. Default: x-www-form-urlencoded"s)
+        .add_optional(
+            "headers"s,
+            &Arguments::headers,
+            { },
+            { "-H"s, "--headers"s },
+            "Headers to add to request. Default <none>"s,
+            header_parser_factory)
         .add_positional(
             "base_url"s,
             &Arguments::base_url,

--- a/parameters/arguments.h
+++ b/parameters/arguments.h
@@ -7,6 +7,7 @@
 
 #include "argparsing/argparsing.h"
 #include "requests/requestmethod.h"
+#include "models/header.h"
 
 struct Arguments
 {
@@ -24,6 +25,7 @@ struct Arguments
     uint32_t thread_count;
     std::string request_body;
     std::string content_type;
+    std::vector<Header> headers;
 };
 
 ap::ArgumentParser<Arguments> createArgumentParser();

--- a/parameters/parameter_conversions.h
+++ b/parameters/parameter_conversions.h
@@ -7,8 +7,10 @@
 
 #include "cdif/cdif.h"
 #include "requests/requestmethod.h"
+#include "models/header.h"
 
 std::function<std::vector<uint16_t>(const std::string&)> status_code_parser_factory(const cdif::Container& ctx);
 std::function<std::vector<uint32_t>(const std::string&)> content_length_parser_factory(const cdif::Container& ctx);
 std::function<std::vector<std::string>(const std::string&)> request_template_parser_factory(const cdif::Container& ctx);
 std::function<RequestMethod(const std::string&)> request_method_parser_factory(const cdif::Container& ctx);
+std::function<std::vector<Header>(const std::string&)> header_parser_factory(const cdif::Container&);

--- a/requests/requestexecutor.cpp
+++ b/requests/requestexecutor.cpp
@@ -35,10 +35,15 @@ bool RequestExecutor::passes_content_length_check(const uint32_t content_length)
             == _args.ignore_content_lengths.end();
 }
 
+uint32_t get_content_length(cpr::Response& response)
+{
+    return std::atoi(response.header["Content-Length"].c_str());
+}
+
 bool RequestExecutor::response_passes_checks(cpr::Response& response) const
 {
     return status_code_indicates_existance(response.status_code) &&
-        passes_content_length_check(std::atoi(response.header["Content-Length"].c_str()));
+        passes_content_length_check(get_content_length(response));
 }
 
 cpr::Response RequestExecutor::get_response(const std::string& url, const std::string& data)
@@ -66,7 +71,15 @@ std::optional<std::string> RequestExecutor::execute(const std::string& item, con
     if (response_passes_checks(response))
     {
         auto message_addendum = (data != ""s) ? "\" - \""s + data : ""s;
-        _context->logger.log_line("\""s + url + message_addendum + "\" - "s + std::to_string(response.status_code));
+        _context->logger.log_line(
+            "\""s
+            + url
+            + message_addendum
+            + "\" - "s
+            + std::to_string(get_content_length(response))
+            + " (CL) - "s
+            + std::to_string(response.status_code)
+            + " (S)"s);
         return url;
     }
 

--- a/requests/requestexecutor.h
+++ b/requests/requestexecutor.h
@@ -36,7 +36,8 @@ class RequestExecutor {
                 args.password,
                 !args.ignore_ssl_errors,
                 args.request_method,
-                args.content_type),
+                args.content_type,
+                args.headers),
             _args(args)
         {}
 

--- a/requests/requestfactory.cpp
+++ b/requests/requestfactory.cpp
@@ -1,5 +1,6 @@
 #include "requestfactory.h"
 
+#include <map>
 #include <string>
 #include <functional>
 
@@ -10,8 +11,8 @@
 cpr::Response RequestFactory::make_request(const std::string& url) const
 {
     if (_user == "")
-        return _make_request(cpr::Url(url), cpr::VerifySsl(_verify_ssl));
-    return _make_request(cpr::Url(url), cpr::Authentication(_user, _pass), cpr::VerifySsl(_verify_ssl));
+        return _make_request(cpr::Url(url), cpr::VerifySsl(_verify_ssl), _create_header());
+    return _make_request(cpr::Url(url), cpr::Authentication(_user, _pass), cpr::VerifySsl(_verify_ssl), _create_header());
 }
 
 cpr::Response RequestFactory::make_request(const std::string& url, const std::string& body_data) const
@@ -23,12 +24,26 @@ cpr::Response RequestFactory::make_request(const std::string& url, const std::st
             cpr::Url(url),
             cpr::VerifySsl(_verify_ssl),
             cpr::Body(body_data),
-            cpr::Header{{"Content-Type"s, _content_type}});
+            _create_header());
     return cpr::Post(
         cpr::Url(url),
         cpr::VerifySsl(_verify_ssl),
         cpr::Authentication(_user, _pass),
         cpr::Body(body_data),
-        cpr::Header{{"Content-Type"s, _content_type}});
+        _create_header());
+}
+
+cpr::Header RequestFactory::_create_header() const
+{
+    using namespace std::string_literals;
+
+    std::map<std::string, std::string> map = {};
+    for (const auto& header : _headers)
+        map[header.name] = header.value;
+
+    if (_content_type != ""s)
+        map["Content-Type"s] = _content_type;
+
+    return cpr::Header(map.begin(), map.end());
 }
 

--- a/requests/requestfactory.h
+++ b/requests/requestfactory.h
@@ -2,10 +2,12 @@
 
 #include <string>
 #include <functional>
+#include <vector>
 
 #include <cpr/cpr.h>
 
 #include "requests/requestmethod.h"
+#include "models/header.h"
 
 class RequestFactory
 {
@@ -15,6 +17,7 @@ class RequestFactory
         bool _verify_ssl;
         RequestMethod _request_method;
         std::string _content_type;
+        std::vector<Header> _headers;
 
         template <typename ... TArgs>
         cpr::Response _make_request(TArgs&&... args) const
@@ -30,6 +33,8 @@ class RequestFactory
             return cpr::Head(args...);
         }
 
+        cpr::Header _create_header() const;
+
     public:
         RequestFactory()
             : _user(), _pass(), _request_method(RequestMethod::HEAD) {}
@@ -39,13 +44,15 @@ class RequestFactory
                 const std::string& pass,
                 bool verify_ssl,
                 const RequestMethod& request_method,
-                const std::string& content_type)
+                const std::string& content_type,
+                const std::vector<Header>& headers)
             :
                 _user(user),
                 _pass(pass),
                 _verify_ssl(verify_ssl),
                 _request_method(request_method),
-                _content_type(content_type)
+                _content_type(content_type),
+                _headers(headers)
         {}
 
         cpr::Response make_request(const std::string& url) const;


### PR DESCRIPTION
Adds `-H|--header` option to allow specifying any headers `;` delimited
to append to the request. Useful for finding files behind a login wall.

Additionally adds content length as a default output, to make the ignore
content length option easier to navigate